### PR TITLE
fix error save installation

### DIFF
--- a/ObjcSegmentPushApp/ViewController.m
+++ b/ObjcSegmentPushApp/ViewController.m
@@ -277,6 +277,8 @@
             [self getInstallation];
         } else {
             self.statusLabel.text = [NSString stringWithFormat:@"更新に失敗しました:%ld",(long)error.code];
+            // 保存に失敗した場合は、installationから削除する
+            [self.installation removeObjectForKey:self.addFieldManager.keyStr];
         }
     }];
 }


### PR DESCRIPTION
・keyに日本語入力されてしまうバグを修正しました

### 今回改善するバグの詳細
* 通常新規フィールド追加時に、keyとして日本語文字列が入力された場合「400004(フォーマットが不正)」のエラーが発生するべき仕様のところ、アプリ画面上では日本語登録ができてしまった
 * 更新ボタンの連打が問題か？
* アプリの再起動をしても画面上データは消えないため修正を依頼